### PR TITLE
Consensus: change operator for older boost

### DIFF
--- a/src/policy/stake.cpp
+++ b/src/policy/stake.cpp
@@ -60,9 +60,9 @@ bool IsDestinationSame(const CScript& a, const CScript& b)
         return false;
     }
 
-    if (aDest != bDest) {
-        return false;
+    if (aDest == bDest) {
+        return true;
     }
 
-    return true;
+    return false;
 }


### PR DESCRIPTION
boost::variant's operator "!=" is not compatible for older version boost library.

It does not exist in ver 1.57.
https://www.boost.org/doc/libs/1_57_0/doc/html/boost/variant.html

It exist in ver 1.58.
https://www.boost.org/doc/libs/1_58_0/doc/html/boost/variant.html

I think that it have to replace with "==" operator.